### PR TITLE
Change PBXTarget name to non optional

### DIFF
--- a/Sources/PBXObject.swift
+++ b/Sources/PBXObject.swift
@@ -56,6 +56,14 @@ extension PBXObject {
         return value
     }
 
+    func string(_ key: XcodeUUID) -> String {
+        guard let value = fields[key] as? String else {
+            assertionFailure("Missing field \(key) for \(self)")
+          return ""
+        }
+        return value
+    }
+
     func strings(_ key: XcodeUUID) -> [String] {
         guard let value = fields[key] as? [String] else {
             assertionFailure("Missing field \(key) for \(self)")

--- a/Sources/PBXTarget.swift
+++ b/Sources/PBXTarget.swift
@@ -10,7 +10,7 @@ import Foundation
 
 public /* abstract */ class PBXTarget: PBXProjectItem, PBXBuildConfigurationListable {
 
-    public lazy var name: String? = self.string("name")
+    public lazy var name: String = self.string("name")
     public lazy var productName: String? = self.string("productName")
     public lazy var buildPhases: [PBXBuildPhase] = self.objects("buildPhases")
     public lazy var buildConfigurationList: XCConfigurationList? = self.object("buildConfigurationList")


### PR DESCRIPTION
Adds non optional string function to PBXObject. And changes PBXTarget name to non optional, as it is required for target.